### PR TITLE
Avoid starting server in example script

### DIFF
--- a/ex/qaptcha.pl
+++ b/ex/qaptcha.pl
@@ -23,7 +23,8 @@ any '/' => sub {
   $self->render('index');
 };
 
-app->start();
+app->start unless caller;
+1;
 
 __DATA__
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -1,7 +1,7 @@
 use Test::More;
 use Test::Mojo;
 
-do "ex/qaptcha.pl";
+require 'ex/qaptcha.pl';
 
 my $t = Test::Mojo->new;
 $t->get_ok('/inline')->status_is(200)


### PR DESCRIPTION
## Summary
- prevent `ex/qaptcha.pl` from starting the application when required
- adjust `t/basic.t` to load the example with `require`

## Testing
- `prove -l t/basic.t` *(fails: Can't locate Test/Mojo.pm)*

------
https://chatgpt.com/codex/tasks/task_e_68a301af0604832f8a736400dbd973ac