### PR TITLE
Require Mojolicious 10 and modernize routes

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -11,7 +11,7 @@ my $builder = Module::Build->new(
   release_status     => 'stable',
   configure_requires => {'Module::Build' => 0,},
   build_requires     => {'Module::Build' => 0.4205, 'Test::More' => 0,},
-  requires   => {'Mojolicious' => 5.0,},
+  requires   => {'Mojolicious' => 10.0,},
   share_dir  => 'jquery',
   meta_merge => {
     resources => {

--- a/lib/Mojolicious/Plugin/Qaptcha.pm
+++ b/lib/Mojolicious/Plugin/Qaptcha.pm
@@ -19,37 +19,33 @@ sub register {
   $app->helper(qaptcha_is_unlocked => \&_is_unlocked);
 
   my $r = $app->routes;
-  $r->route($app->config->{qaptcha_url})->to(
-    cb => sub {
-      my $self      = shift;
-      my $aResponse = {};
-      $aResponse->{error} = 0;
+  $r->any($app->config->{qaptcha_url} => sub {
+    my $self      = shift;
+    my $aResponse = {};
+    $aResponse->{error} = 0;
 
-      if ($self->param('action') && $self->param('qaptcha_key')) {
-        $self->session('qaptcha_key', undef);
-        if ($self->param('action') eq 'qaptcha') {
-          $self->session('qaptcha_key', $self->param('qaptcha_key'));
-        }
-        else {
-          $aResponse->{error} = 1;
-        }
-        return $self->render(json => $aResponse);
+    if ($self->param('action') && $self->param('qaptcha_key')) {
+      $self->session('qaptcha_key', undef);
+      if ($self->param('action') eq 'qaptcha') {
+        $self->session('qaptcha_key', $self->param('qaptcha_key'));
       }
       else {
         $aResponse->{error} = 1;
-        return $self->render(json => $aResponse);
       }
+      return $self->render(json => $aResponse);
     }
-  );
-  $r->route('/images/bg_draggable_qaptcha.jpg')->to(
-    cb => sub {
-      my $self = shift;
-      $self->render(
-        data   => slurp(&_basedir . "/bg_draggable_qaptcha.jpg"),
-        format => 'jpg'
-      );
+    else {
+      $aResponse->{error} = 1;
+      return $self->render(json => $aResponse);
     }
-  );
+  });
+  $r->get('/images/bg_draggable_qaptcha.jpg' => sub {
+    my $self = shift;
+    $self->render(
+      data   => slurp(&_basedir . "/bg_draggable_qaptcha.jpg"),
+      format => 'jpg'
+    );
+  });
   $app->hook(
     after_dispatch => sub {
       my $c = shift;


### PR DESCRIPTION
## Summary
- Require Mojolicious 10.0 for plugin
- Update plugin routes to use `any`/`get` callbacks

## Testing
- `prove -l` *(fails: Can't locate Mojo/Base.pm)*

------
https://chatgpt.com/codex/tasks/task_e_68a3019f34d4832fb2f3d57e94a46d8b