### PR TITLE
Handle development vs installed jquery path

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -15,6 +15,7 @@ META.json
 META.yml
 README.pod
 t/00-load.t
+t/basedir.t
 t/basic.t
 t/configurable.t
 t/manifest.t

--- a/lib/Mojolicious/Plugin/Qaptcha.pm
+++ b/lib/Mojolicious/Plugin/Qaptcha.pm
@@ -123,11 +123,8 @@ sub _is_unlocked {
 }
 
 sub _basedir {
-  my $dir
-    = File::Spec->catdir(
-    dirname(__FILE__) . "/../../../jquery" //
-    File::ShareDir::dist_dir('Mojolicious-Plugin-Qaptcha'));
-  return $dir;
+  my $dev = File::Spec->catdir(dirname(__FILE__), '..', '..', '..', 'jquery');
+  return -d $dev ? $dev : File::ShareDir::dist_dir('Mojolicious-Plugin-Qaptcha');
 }
 
 =head1 NAME

--- a/t/basedir.t
+++ b/t/basedir.t
@@ -1,0 +1,30 @@
+use Test::More;
+use File::Spec;
+use File::Basename 'dirname';
+use File::Temp 'tempdir';
+use Cwd 'abs_path';
+
+BEGIN {
+  eval { require Mojolicious::Plugin::Qaptcha; 1 }
+    or plan skip_all => 'Mojolicious::Plugin::Qaptcha required';
+}
+
+subtest 'development mode' => sub {
+  my $expected = abs_path(File::Spec->catdir(dirname(__FILE__), '..', 'jquery'));
+  my $got      = abs_path(Mojolicious::Plugin::Qaptcha::_basedir());
+  is $got, $expected, 'uses development jquery directory';
+};
+
+subtest 'installed mode' => sub {
+  my $dev_dir = File::Spec->catdir(dirname(__FILE__), '..', 'jquery');
+  my $bak     = "$dev_dir.bak";
+  rename $dev_dir, $bak or BAIL_OUT("rename failed: $!");
+  my $share = tempdir(CLEANUP => 1);
+  no warnings 'redefine';
+  local *File::ShareDir::dist_dir = sub { $share };
+  my $basedir = Mojolicious::Plugin::Qaptcha::_basedir();
+  is $basedir, $share, 'fallback to File::ShareDir path';
+  rename $bak, $dev_dir or BAIL_OUT("restore failed: $!");
+};
+
+done_testing;


### PR DESCRIPTION
## Summary
- ensure File::ShareDir is imported and `_basedir` falls back to installed share dir when bundled jquery assets are absent
- add tests covering development vs. installed modes for `_basedir`

## Testing
- `prove -lr t` *(fails: Can't locate Mojo/Base.pm ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a3019052b4832fa0ade3f9143bf9cf