### PR TITLE
Remove unused FindBin import

### DIFF
--- a/lib/Mojolicious/Plugin/Qaptcha.pm
+++ b/lib/Mojolicious/Plugin/Qaptcha.pm
@@ -1,7 +1,6 @@
 package Mojolicious::Plugin::Qaptcha;
 
 use Mojo::Base 'Mojolicious::Plugin';
-use FindBin qw'$Bin';
 use Mojo::File qw(path);
 use File::Basename 'dirname';
 use File::Spec;


### PR DESCRIPTION
## Summary
- Remove `FindBin` import from Mojolicious::Plugin::Qaptcha as it is unused

## Testing
- `perl -c lib/Mojolicious/Plugin/Qaptcha.pm` *(fails: Can't locate Mojo/Base.pm)*
- `prove -l t` *(fails: Can't locate Mojo/Base.pm)*

------
https://chatgpt.com/codex/tasks/task_e_68a30e4bd8dc832fa2a1ce5044dea0d2