### PR TITLE
Fix extra whitespace in qaptcha templates

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -56,12 +56,8 @@ __DATA__
 @@ index.html.ep
 %= layout 'default';
 'Hello Qaptcha!'
-<div id="q_session">
-%= c.session('qaptcha_key');
-</div>
-<div id="f_processed">
-%= $form_processing;
-</div>
+<div id="q_session"><%= c.session('qaptcha_key') %></div>
+<div id="f_processed"><%= $form_processing %></div>
 <form method="post" action="">
   <fieldset>
     <label>First Name</label> <input name="firstname" type="text"><br>

--- a/t/configurable.t
+++ b/t/configurable.t
@@ -72,12 +72,8 @@ __DATA__
 
 @@ index.html.ep
 % layout 'default';
-<div id="q_session">
-<%= $c->session('qaptcha_key') %>
-</div>
-<div id="f_processed">
-%= $form_processing;
-</div>
+<div id="q_session"><%= $c->session('qaptcha_key') %></div>
+<div id="f_processed"><%= $form_processing %></div>
 <form method="post" action="">
   <fieldset>
     <label>First Name</label> <input name="firstname" type="text"><br>


### PR DESCRIPTION
## Summary
- keep qaptcha div placeholders on a single line to avoid stray spaces

## Testing
- `prove -l t/basic.t t/configurable.t` *(fails: Can't locate Test::Mojo.pm)*

------
https://chatgpt.com/codex/tasks/task_e_68a30e4533d0832f9882bce1a3f64324