### PR TITLE
Restrict Qaptcha endpoint to POST

### DIFF
--- a/lib/Mojolicious/Plugin/Qaptcha.pm
+++ b/lib/Mojolicious/Plugin/Qaptcha.pm
@@ -19,7 +19,7 @@ sub register {
   $app->helper(qaptcha_is_unlocked => \&_is_unlocked);
 
   my $r = $app->routes;
-  $r->any($app->config->{qaptcha_url} => sub {
+  $r->post($app->config->{qaptcha_url} => sub {
     my $self      = shift;
     my $aResponse = {};
     $aResponse->{error} = 0;

--- a/t/basic.t
+++ b/t/basic.t
@@ -17,7 +17,7 @@ $t->get_ok('/')->status_is(200)
 $t->get_ok('/images/bg_draggable_qaptcha.jpg')->status_is(200)
   ->content_type_is('image/jpeg');
 
-$t->get_ok('/qaptcha')->status_is(404);
+$t->get_ok('/qaptcha')->status_is(404, 'GET /qaptcha returns 404');
 
 $t->post_ok('/' => {DNT => 1} => form => {firstname => 'hans', lastname => 'test'})
   ->status_is(200)

--- a/t/configurable.t
+++ b/t/configurable.t
@@ -42,7 +42,7 @@ $t->post_ok('/entsperren' => {DNT => 1} => form => {action => 'qaptcha', qaptcha
   ->status_is(200)
   ->json_is({error => 0});
 
-$t->get_ok('/entsperren')->status_is(404);
+$t->get_ok('/entsperren')->status_is(404, 'GET /entsperren returns 404');
 
   $t->post_ok('/' => {DNT => 1} => form => {firstname => 'hans', lastname => 'test'})
   ->status_is(200)


### PR DESCRIPTION
## Summary
- Limit Qaptcha unlock route to POST requests
- Update tests to assert GET requests return 404

## Testing
- `prove -l t/basic.t t/configurable.t` *(fails: Can't locate Test::Mojo)*


------
https://chatgpt.com/codex/tasks/task_e_68a30e31ee24832f96166a477af95e99