### PR TITLE
Handle blib paths in _basedir lookup

### DIFF
--- a/lib/Mojolicious/Plugin/Qaptcha.pm
+++ b/lib/Mojolicious/Plugin/Qaptcha.pm
@@ -3,7 +3,7 @@ package Mojolicious::Plugin::Qaptcha;
 use Mojo::Base 'Mojolicious::Plugin';
 use FindBin qw'$Bin';
 use Mojo::File qw(path);
-use File::Basename 'dirname';
+use File::Basename qw(dirname basename);
 use File::Spec;
 use File::ShareDir;
 
@@ -119,7 +119,9 @@ sub _is_unlocked {
 }
 
 sub _basedir {
-  my $dev = File::Spec->catdir(dirname(__FILE__), '..', '..', '..', 'jquery');
+  my $root = File::Spec->catdir(dirname(__FILE__), ('..') x 3);
+  $root = File::Spec->catdir($root, '..') if basename($root) eq 'blib';
+  my $dev = File::Spec->catdir($root, 'jquery');
   return -d $dev ? $dev : File::ShareDir::dist_dir('Mojolicious-Plugin-Qaptcha');
 }
 


### PR DESCRIPTION
## Summary
- Ensure `_basedir` resolves the project `jquery` directory even when module is loaded from `blib`
- Fall back to `File::ShareDir` only when the `jquery` folder is missing

## Testing
- `prove -l` *(fails: Can't locate Mojo/Base.pm)*

------
https://chatgpt.com/codex/tasks/task_e_68a30e1ffdd8832fb0aff7c24216df52