### PR TITLE
Handle blib share paths when locating distribution resources

### DIFF
--- a/lib/Mojolicious/Plugin/Qaptcha.pm
+++ b/lib/Mojolicious/Plugin/Qaptcha.pm
@@ -118,10 +118,27 @@ sub _is_unlocked {
 }
 
 sub _basedir {
-  my $root = File::Spec->catdir(dirname(__FILE__), ('..') x 3);
-  $root = File::Spec->catdir($root, '..') if basename($root) eq 'blib';
-  my $dev = File::Spec->catdir($root, 'jquery');
-  return -d $dev ? $dev : File::ShareDir::dist_dir('Mojolicious-Plugin-Qaptcha');
+  my @parts = File::Spec->splitdir(File::Spec->rel2abs(dirname(__FILE__)));
+
+  for (my $i = 0; $i <= $#parts; $i++) {
+    if ($parts[$i] eq 'blib') { splice @parts, $i--, 1; next }
+    if ($i <= $#parts - 3
+      && $parts[$i] eq 'auto'
+      && $parts[$i + 1] eq 'share'
+      && $parts[$i + 2] eq 'dist')
+    {
+      splice @parts, $i--, 4;
+    }
+  }
+
+  while (@parts) {
+    my $dir    = File::Spec->catdir(@parts);
+    my $jquery = File::Spec->catdir($dir, 'jquery');
+    return $jquery if -d $jquery;
+    pop @parts;
+  }
+
+  return File::ShareDir::dist_dir('Mojolicious-Plugin-Qaptcha');
 }
 
 =head1 NAME

--- a/t/basedir.t
+++ b/t/basedir.t
@@ -3,6 +3,8 @@ use File::Spec;
 use File::Basename 'dirname';
 use File::Temp 'tempdir';
 use Cwd 'abs_path';
+use File::Path 'make_path';
+use File::Copy 'copy';
 
 BEGIN {
   eval { require Mojolicious::Plugin::Qaptcha; 1 }
@@ -25,6 +27,31 @@ subtest 'installed mode' => sub {
   my $basedir = Mojolicious::Plugin::Qaptcha::_basedir();
   is $basedir, $share, 'fallback to File::ShareDir path';
   rename $bak, $dev_dir or BAIL_OUT("restore failed: $!");
+};
+
+subtest 'blib share mode' => sub {
+  my $base = tempdir(CLEANUP => 1);
+
+  my $libdir = File::Spec->catdir(
+    $base, qw(blib lib auto share dist Mojolicious-Plugin-Qaptcha lib)
+  );
+  my $moddir = File::Spec->catdir($libdir, qw(Mojolicious Plugin));
+  make_path($moddir);
+  my $src
+    = File::Spec->catfile(dirname(__FILE__), '..', 'lib', 'Mojolicious', 'Plugin',
+    'Qaptcha.pm');
+  copy($src, File::Spec->catfile($moddir, 'Qaptcha.pm'))
+    or BAIL_OUT("copy failed: $!");
+
+  make_path(File::Spec->catdir($base, 'jquery'));
+
+  local @INC = ($libdir, @INC);
+  delete $INC{'Mojolicious/Plugin/Qaptcha.pm'};
+  no warnings 'redefine';
+  require Mojolicious::Plugin::Qaptcha;
+  my $got      = abs_path(Mojolicious::Plugin::Qaptcha::_basedir());
+  my $expected = abs_path(File::Spec->catdir($base, 'jquery'));
+  is $got, $expected, 'works with blib/lib/auto/share module';
 };
 
 done_testing;


### PR DESCRIPTION
## Summary
- Improve `_basedir` to walk up from the module file, skipping `blib` and `auto/share/dist/*` segments, and locate the closest `jquery` directory
- Fall back to `File::ShareDir` when no `jquery` directory is present
- Extend `t/basedir.t` to verify `_basedir` with modules loaded from `blib/lib/auto/share`

## Testing
- `prove -lr t` *(fails: Can't locate Mojo/Base.pm)*

------
https://chatgpt.com/codex/tasks/task_e_68a3143a18d0832f95ce8b553de60e4a