### PR TITLE
Fix form data processed message

### DIFF
--- a/ex/qaptcha.pl
+++ b/ex/qaptcha.pl
@@ -17,8 +17,8 @@ get '/inline' => sub {
 any '/' => sub {
   my $self = shift;
   $self->stash(
-    form_processing => sprintf("form data %s processed",
-      $self->qaptcha_is_unlocked ? '' : 'not')
+    form_processing => sprintf("form data%s processed",
+      $self->qaptcha_is_unlocked ? '' : ' not')
   );
   $self->render('index');
 };

--- a/t/configurable.t
+++ b/t/configurable.t
@@ -21,8 +21,8 @@ plugin 'Qaptcha', {
 any '/' => sub {
   my $self = shift;
   $self->stash(
-    form_processing => sprintf("form data %s processed",
-      $self->qaptcha_is_unlocked ? '' : 'not')
+    form_processing => sprintf("form data%s processed",
+      $self->qaptcha_is_unlocked ? '' : ' not')
   );
   $self->render('index');
 };


### PR DESCRIPTION
## Summary
- avoid double-space in form_processing message
- ensure configurable test uses same logic

## Testing
- `prove -lv t/basic.t t/configurable.t` *(fails: Can't locate Test/Mojo.pm)*

------
https://chatgpt.com/codex/tasks/task_e_68a3143e4bdc832f91f537130e68faf1