### PR TITLE
Fix test script include path for Qaptcha example

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -1,7 +1,8 @@
 use Test::More;
 use Test::Mojo;
 
-require 'ex/qaptcha.pl';
+use FindBin;
+require "$FindBin::Bin/../ex/qaptcha.pl";
 
 my $t = Test::Mojo->new;
 $t->get_ok('/inline')->status_is(200)


### PR DESCRIPTION
## Summary
- use `FindBin` to locate example script in `t/basic.t`

## Testing
- `prove -lv t/` *(fails: Can't locate Mojo/Base.pm in @INC)*

------
https://chatgpt.com/codex/tasks/task_e_68a44ad8eee0832faa59e1590823c53a